### PR TITLE
Bug 1367171 - Extend Flash shield study duration to 60 days

### DIFF
--- a/lib/study.js
+++ b/lib/study.js
@@ -9,7 +9,7 @@ const PROBABILITY_OF_CONTROL_GROUP = 0.5;
 
 const studyConfig = {
   name: self.addonId,
-  duration: 14,
+  duration: 60,
   surveyUrls:  {
     'end-of-study': 'https://qsurvey.mozilla.com/s3/shield-plugin-sec-eos',
     'user-ended-study': 'https://qsurvey.mozilla.com/s3/shield-plugin-sec-eos',


### PR DESCRIPTION
because that was always the plan. (42 + some wiggle room)

r? @squarewave 